### PR TITLE
feat: integrate callable tools and add web search (#2)

### DIFF
--- a/claw_swarm/agent/main.py
+++ b/claw_swarm/agent/main.py
@@ -44,7 +44,7 @@ from claw_swarm.prompts import (
     build_agent_system_prompt,
 )
 from claw_swarm.tools import run_claude_agent
-from claw_swarm.tools.launch_tokens import claim_fees, launch_token
+from claw_swarm.tools.tools_registry import tools as registered_tools
 
 
 def call_claude(task: str) -> str:
@@ -126,5 +126,5 @@ def create_agent(
         model_name=model_name,
         max_loops=1,
         output_type="final",
-        tools=[launch_token, claim_fees],
+        tools=registered_tools,
     )

--- a/claw_swarm/tools/__init__.py
+++ b/claw_swarm/tools/__init__.py
@@ -1,4 +1,5 @@
 from claw_swarm.tools.launch_tokens import claim_fees, launch_token
+from claw_swarm.tools.web_search import web_search
 from claw_swarm.tools.claude_code_tool import (
     run_claude_agent,
     run_claude_agent_async,
@@ -11,4 +12,5 @@ __all__ = [
     "run_claude_agent",
     "run_claude_agent_async",
     "stream_claude_agent",
+    "web_search",
 ]

--- a/claw_swarm/tools/tools_registry.py
+++ b/claw_swarm/tools/tools_registry.py
@@ -1,11 +1,15 @@
-from swarms_tools import exa_search
-
 from claw_swarm.tools.claude_code_tool import (
     run_claude_agent,
     run_claude_agent_async,
     stream_claude_agent,
 )
 from claw_swarm.tools.launch_tokens import claim_fees, launch_token
+from claw_swarm.tools.web_search import web_search
+
+try:
+    from swarms_tools import exa_search
+except Exception:
+    exa_search = None
 
 tools = [
     claim_fees,
@@ -13,5 +17,8 @@ tools = [
     run_claude_agent,
     run_claude_agent_async,
     stream_claude_agent,
-    exa_search,
+    web_search,
 ]
+
+if exa_search is not None:
+    tools.append(exa_search)

--- a/claw_swarm/tools/web_search.py
+++ b/claw_swarm/tools/web_search.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def web_search(query: str, max_results: int = 5) -> list[dict[str, Any]]:
+    """
+    Run a web search and return normalized lightweight results.
+
+    Returns a list of objects with keys: title, url, snippet.
+    """
+    q = (query or "").strip()
+    if not q:
+        return []
+
+    try:
+        from duckduckgo_search import DDGS
+    except Exception as exc:
+        raise RuntimeError(
+            "duckduckgo-search is not installed; install it to use web_search"
+        ) from exc
+
+    limit = max(1, min(int(max_results), 10))
+    with DDGS() as ddgs:
+        rows = ddgs.text(q, max_results=limit) or []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            out.append(
+                {
+                    "title": row.get("title", ""),
+                    "url": row.get("href", ""),
+                    "snippet": row.get("body", ""),
+                }
+            )
+        return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ pydantic = "*"
 aiohttp = "*"
 swarms = "*"
 loguru = "*"
+duckduckgo-search = "*"
 
 [tool.poetry.scripts]
 clawswarm = "claw_swarm.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydantic
 aiohttp
 swarms
 loguru
+duckduckgo-search

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -1,0 +1,43 @@
+"""
+Unit tests for claw_swarm.tools.tools_registry and web_search.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from claw_swarm.tools import tools_registry
+from claw_swarm.tools.web_search import web_search
+
+
+def test_registry_contains_core_tools():
+    names = {getattr(tool, "__name__", "") for tool in tools_registry.tools}
+    assert "launch_token" in names
+    assert "claim_fees" in names
+    assert "run_claude_agent" in names
+    assert "web_search" in names
+
+
+def test_web_search_returns_empty_for_blank_query():
+    assert web_search("   ") == []
+
+
+def test_web_search_normalizes_results():
+    fake_results = [
+        {"title": "Result 1", "href": "https://a", "body": "one"},
+        {"title": "Result 2", "href": "https://b", "body": "two"},
+    ]
+    ddgs = MagicMock()
+    ddgs.text.return_value = fake_results
+
+    manager = MagicMock()
+    manager.__enter__.return_value = ddgs
+    manager.__exit__.return_value = False
+
+    with patch("duckduckgo_search.DDGS", return_value=manager):
+        rows = web_search("python", max_results=2)
+
+    assert rows == [
+        {"title": "Result 1", "url": "https://a", "snippet": "one"},
+        {"title": "Result 2", "url": "https://b", "snippet": "two"},
+    ]


### PR DESCRIPTION
## Summary
Implements issue #2 by wiring the agent to the centralized tool registry and adding built-in web search capability.

## Changes
- Added  tool backed by DuckDuckGo ()
- Updated  to include core tools plus optional 
- Updated agent construction to use the centralized registry so tools are callable by the agent
- Added focused unit tests for tool registry and web search normalization
- Added dependency entries for 

## Validation
- ................                                                         [100%]
16 passed in 4.71s

Closes #2